### PR TITLE
Psi-Armour and nullglass fixes

### DIFF
--- a/code/datums/extensions/armor/armor_psionic.dm
+++ b/code/datums/extensions/armor/armor_psionic.dm
@@ -5,8 +5,10 @@
 
 /datum/extension/armor/psionic/get_value(key)
 	var/datum/psi_complexus/psi = holder
-	psi.get_armour(key)
+	return psi.get_armour(key)
 
 /datum/extension/armor/psionic/on_blocking(damage, damage_type, damage_flags, armor_pen, blocked)
 	var/datum/psi_complexus/psi = holder
-	psi.spend_power(round(damage * blocked))
+	var/blocked_damage = round(damage * blocked)
+	if(blocked_damage)
+		psi.spend_power(blocked_damage)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -65,7 +65,10 @@ meteor_act
 	if(!istype(def_zone))
 		def_zone = get_organ(check_zone(def_zone))
 	if(!def_zone)
-		return
+		return ..()
+
+	. = list()
+
 	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
 	for(var/obj/item/clothing/gear in protective_gear)
 		if(gear.accessories.len)
@@ -78,6 +81,9 @@ meteor_act
 			var/armor = get_extension(gear, /datum/extension/armor)
 			if(armor)
 				. += armor
+
+	// Add inherent armor to the end of list so that protective equipment is checked first
+	. += ..()
 
 //this proc returns the Siemens coefficient of electrical resistivity for a particular external organ.
 /mob/living/carbon/human/proc/get_siemens_coefficient_organ(var/obj/item/organ/external/def_zone)

--- a/code/modules/psionics/complexus/complexus.dm
+++ b/code/modules/psionics/complexus/complexus.dm
@@ -12,13 +12,13 @@
 	var/next_power_use = 0            // world.time minimum before next power use.
 	var/stamina = 50                  // Current psi pool.
 	var/max_stamina = 50              // Max psi pool.
+	var/armour_cost = 0				  // Amount of power to substract this tick from psi armour blocking damage.
 
 	var/list/latencies                // List of all currently latent faculties.
 	var/list/ranks                    // Assoc list of psi faculties to current rank.
 	var/list/base_ranks               // Assoc list of psi faculties to base rank, in case reset is needed
 	var/list/manifested_items         // List of atoms manifested/maintained by psychic power.
 	var/next_latency_trigger = 0      // world.time minimum before a trigger can be attempted again.
-	var/last_armor_check              // world.time of last armour check.
 	var/last_aura_size
 	var/last_aura_alpha
 	var/last_aura_color

--- a/code/modules/psionics/complexus/complexus_helpers.dm
+++ b/code/modules/psionics/complexus/complexus_helpers.dm
@@ -15,11 +15,9 @@
 	cancel()
 
 /datum/psi_complexus/proc/get_armour(var/armourtype)
-	if(can_use_passive())
-		last_armor_check = world.time
+	if(use_psi_armour && can_use_passive())
 		return round(Clamp(Clamp(4 * rating, 0, 20) * get_rank(SSpsi.armour_faculty_by_type[armourtype]), 0, 100) * (stamina/max_stamina))
 	else
-		last_armor_check = 0
 		return 0
 
 /datum/psi_complexus/proc/get_rank(var/faculty)
@@ -58,6 +56,9 @@
 			stamina = 0
 			. = FALSE
 		ui.update_icon()
+
+/datum/psi_complexus/proc/spend_power_armour(var/value = 0)
+	armour_cost += value
 
 /datum/psi_complexus/proc/hide_auras()
 	if(owner.client)

--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -78,6 +78,16 @@
 /datum/psi_complexus/Process()
 
 	var/update_hud
+	if(armour_cost)
+		var/value = max(1, ceil(armour_cost * cost_modifier))
+		if(value <= stamina)
+			stamina -= value
+		else
+			backblast(abs(stamina - value))
+			stamina = 0
+		update_hud = TRUE
+		armour_cost = 0
+
 	if(stun)
 		stun--
 		if(stun)
@@ -87,25 +97,22 @@
 		else
 			to_chat(owner, SPAN_NOTICE("You have recovered your mental composure."))
 			update_hud = TRUE
-		return
+	else
+		var/psi_leech = owner.do_psionics_check()
+		if(psi_leech)
+			if(stamina > 10)
+				stamina = max(0, stamina - rand(15,20))
+				to_chat(owner, SPAN_DANGER("You feel your psi-power leeched away by \the [psi_leech]..."))
+			else
+				stamina++
+		else if(stamina < max_stamina)
+			if(owner.stat == CONSCIOUS)
+				stamina = min(max_stamina, stamina + rand(1,3))
+			else if(owner.stat == UNCONSCIOUS)
+				stamina = min(max_stamina, stamina + rand(3,5))
 
-	var/psi_leech = owner.do_psionics_check()
-	if(psi_leech)
-		if(stamina > 10)
-			stamina = max(0, stamina - rand(15,20))
-			to_chat(owner, SPAN_DANGER("You feel your psi-power leeched away by \the [psi_leech]..."))
-		else
-			stamina++
-		return
-
-	else if(stamina < max_stamina)
-		if(owner.stat == CONSCIOUS)
-			stamina = min(max_stamina, stamina + rand(1,3))
-		else if(owner.stat == UNCONSCIOUS)
-			stamina = min(max_stamina, stamina + rand(3,5))
-
-	if(!owner.nervous_system_failure() && owner.stat == CONSCIOUS && stamina && !suppressed && get_rank(PSI_REDACTION) >= PSI_RANK_OPERANT)
-		attempt_regeneration()
+		if(!owner.nervous_system_failure() && owner.stat == CONSCIOUS && stamina && !suppressed && get_rank(PSI_REDACTION) >= PSI_RANK_OPERANT)
+			attempt_regeneration()
 
 	var/next_aura_size = max(0.1,((stamina/max_stamina)*min(3,rating))/5)
 	var/next_aura_alpha = round(((suppressed ? max(0,rating - 2) : rating)/5)*255)

--- a/code/modules/psionics/null/material_sheet.dm
+++ b/code/modules/psionics/null/material_sheet.dm
@@ -13,8 +13,8 @@
 
 /obj/item/stack/material/nullglass
 	name = "nullglass"
-	icon_state = "sheet-shiny"
-	plural_icon_state = "sheet-shiny-mult"
+	icon_state = "sheet-clear"
+	plural_icon_state = "sheet-clear-mult"
 	default_type = MATERIAL_NULLGLASS
 
 /obj/item/stack/material/nullglass/fifty


### PR DESCRIPTION
Ports Psi-Armour fix from NebulaSS13 which should hopefully fully fix one of the last remaining base issues with the Psychics subsystem.
Each faculty's associated Psi-Armour is as follows:
- Coercion: psionic attacks.
- Energistics: bombs, lasers, energy attacks.
- Psychokinesis: bullets, melee attacks.
- Redaction: bio/toxins, radiation.

Fixes nullglass sheets not having the correct sprite and being invisible when created.
Now we actually have a way to create them in-game this needed to be fixed.