### PR TITLE
Booster QoL tweak

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -464,6 +464,32 @@ SUBSYSTEM_DEF(jobs)
 		// Transfers the skill settings for the job to the mob
 		H.skillset.obtain_from_client(job, H.client)
 
+		// I'm only doing this here because I don't know where else to put it...
+		// ...And I want it to be above job.setup_account(H) since that also puts stuff in memory.
+		if(H.get_species() == SPECIES_BOOSTER)
+			var/rememberedMods = "<b>Your [H.get_species()] modifiers are:</b><br>"
+			// Add something here about visible mods, ie: "You have a pair of cat ears." etc
+			if(H.species.get_brute_mod(H))
+				rememberedMods += "Brute resistance: [H.species.get_brute_mod(H)]x<br>"
+			if(H.species.get_burn_mod(H))
+				rememberedMods += "Burn resistance: [H.species.get_burn_mod(H)]x<br>"
+			if(H.species.get_toxins_mod(H))
+				rememberedMods += "Toxin resistance: [H.species.get_toxins_mod(H)]x<br>"
+			if(H.species.get_radiation_mod(H))
+				rememberedMods += "Radiation resistance: [H.species.get_radiation_mod(H)]x<br>"
+			if(H.species.get_slowdown(H))
+				var/slowdown = H.species.get_slowdown(H)
+				var/speed = ""
+				if(slowdown == 0.5)
+					speed = "slower than"
+				else if(slowdown == -0.5)
+					speed = "faster than"
+				else if(slowdown == 0)
+					speed = "on par with"
+				rememberedMods += "Your slowdown modifier is: [slowdown], making you [speed] the average for a [H.get_species()].<br>"
+
+			H.StoreMemory(rememberedMods, /decl/memory_options/system)
+
 		//Equip job items.
 		job.setup_account(H)
 
@@ -561,6 +587,10 @@ SUBSYSTEM_DEF(jobs)
 
 	if(job.req_admin_notify)
 		to_chat(H, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
+
+	if(H.get_species() == SPECIES_BOOSTER())
+		// Mostly booster specific right now.
+		to_chat(H, SPAN_NOTICE("As a [H.get_species()], your notes have specifics on your current modifiers."))
 
 	//Gives glasses to the vision impaired
 	if(H.disabilities & NEARSIGHTED)

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -265,7 +265,7 @@ var/global/datum/ntnet/ntnet_global = new()
 		if(user.mind)
 			user.mind.initial_email_login["login"] = EA.login
 			user.mind.initial_email_login["password"] = EA.password
-			user.StoreMemory("Your email account address is [EA.login] and the password is [EA.password].", /decl/memory_options/system)
+			user.StoreMemory("Your email account address is [EA.login] and the password is [EA.password].<br>", /decl/memory_options/system)
 		if(issilicon(user))
 			var/mob/living/silicon/S = user
 			var/datum/nano_module/email_client/my_client = S.get_subsystem_from_path(/datum/nano_module/email_client)


### PR DESCRIPTION
Adds information concerning mutable Booster stats to character's notes/memory on roundstart, allowing you to actually see how you're affected.
This includes brute, burn, toxin and radiation resistance, along with your slowdown modifier.

This should be a nice QoL fix for those of us that keep getting disoriented by being very slow and weak one round, and being a super-strength zoomer Booster the next.